### PR TITLE
Fix bugs and add arm64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
+ERIGON_IMAGE_TAG=2.58.0-arm64
+
+up-arm64:
+	ERIGON_IMAGE_TAG=$(ERIGON_IMAGE_TAG) docker compose up -d
+
 clean:
-	docker ps -a -q | xargs --no-run-if-empty docker rm -f
+	docker ps -a -q | xargs docker rm -f
 	sudo rm -rf ./consensus/beacondata* ./consensus/validatordata ./consensus/genesis.ssz
 	sudo rm -rf ./execution/geth ./execution/erigon

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ sudo chown -R $USER:$USER execution/erigon.bak/
     --no-downloader=true \
     --maxpeers 0 \
     --datadir=./execution/erigon.bak \
+    --networkid=32382 \
     --db.size.limit=1GB
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,9 +88,9 @@ services:
       - --db.size.limit=1GB
       - --networkid=32382
     ports:
-      - 18551:8551
-      - 18545:8545
-      - 18546:8546
+      - 8551:8551
+      - 8545:8545
+      - 8546:8546
     depends_on:
       erigon-genesis:
         condition: service_completed_successfully

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,33 +26,9 @@ services:
       - ./consensus:/consensus
       - ./execution:/execution
 
-  # Sets up the genesis configuration for the go-ethereum client from a JSON file.
-  geth-genesis:
-    image: "ethereum/client-go:latest"
-    command: --datadir=/execution/geth init /execution/genesis.json
-    volumes:
-      - ./execution:/execution
-      - ./execution/genesis.json:/execution/genesis.json
-    depends_on:
-      create-beacon-chain-genesis:
-        condition: service_completed_successfully
-
-  geth-import:
-    image: "ethereum/client-go:latest"
-    command: --datadir=/execution/geth account import --password /execution/geth_password.txt /execution/sk.json
-    volumes:
-      - ./execution:/execution
-      - ./execution/genesis.json:/execution/genesis.json
-    depends_on:
-      create-beacon-chain-genesis:
-        condition: service_completed_successfully
-
   erigon-genesis:
-    image: "thorax/erigon:devel"
-    user: root
-    command: 
-      - --datadir=/execution/erigon init /execution/genesis.json
-      - --db.size.limit=1GB
+    image: "thorax/erigon:${ERIGON_IMAGE_TAG:-devel}"
+    command: --datadir=/execution/erigon init /execution/genesis.json
     volumes:
       - ./execution:/execution
       - ./execution/genesis.json:/execution/genesis.json
@@ -60,59 +36,11 @@ services:
       create-beacon-chain-genesis:
         condition: service_completed_successfully
 
-  # Runs a Prysm beacon chain from a specified genesis state created in the previous step
-  # and connects to go-ethereum in the same network as the execution client.
-  # The account used in go-ethereum is set as the suggested fee recipient for transactions
-  # proposed via the validators attached to the beacon node.
-  beacon-chain-1:
-    image: "gcr.io/prysmaticlabs/prysm/beacon-chain:v4.0.8"
-    command:
-      - --datadir=/consensus/beacondata
-      - --min-sync-peers=0
-      - --genesis-state=/consensus/genesis.ssz
-      - --bootstrap-node=
-      - --interop-eth1data-votes
-      - --chain-config-file=/consensus/config.yml
-      - --contract-deployment-block=0
-      - --chain-id=${CHAIN_ID:-32382}
-      - --rpc-host=0.0.0.0
-      - --grpc-gateway-host=0.0.0.0
-      - --execution-endpoint=http://geth:8551
-      - --accept-terms-of-use
-      - --jwt-secret=/execution/jwtsecret
-      - --suggested-fee-recipient=0x85da99c8a7c2c95964c8efd687e95e632fc533d6
-      - --minimum-peers-per-subnet=0
-      - --enable-debug-rpc-endpoints
-      - --p2p-static-id
-      - --p2p-tcp-port=13000
-    depends_on:
-      create-beacon-chain-genesis:
-        condition: service_completed_successfully
-      create-beacon-node-keys:
-        condition: service_completed_successfully
-    ports:
-      - 4000:4000
-      - 3500:3500
-      - 8080:8080
-      - 6060:6060
-      - 9090:9090
-      - 13000:13000
-    volumes:
-      - ./consensus:/consensus
-      - ./execution:/execution
-      - ./execution/jwtsecret:/execution/jwtsecret
-    networks:
-      polygon-net:
-        ipv4_address: 10.100.100.10
-
-
-  beacon-chain-2:
-    image: "gcr.io/prysmaticlabs/prysm/beacon-chain:v4.0.8"
+  beacon-chain:
+    image: "gcr.io/prysmaticlabs/prysm/beacon-chain:v4.2.0"
     command:
       - --datadir=/consensus/beacondata-2
-      - --bootstrap-node=enr:-MK4QM1Wi7H-T52YEzJ1Ja--DIrqvp1VUMH7CoewzDk5rAIbTO4zfbsY-wOvFqdiPpqki5S1Lj5_nOVpleE_BldN6h-GAYv3b291h2F0dG5ldHOIAAAAAAAAAACEZXRoMpBa8xKTIAAAkv__________gmlkgnY0gmlwhApkZAqJc2VjcDI1NmsxoQI778OxC5HP9v87abs54E1H8n8Jo3fVGH2XsQwmBDEI1ohzeW5jbmV0cwCDdGNwgjLIg3VkcIIu4A
-      - --peer=enr:-MK4QM1Wi7H-T52YEzJ1Ja--DIrqvp1VUMH7CoewzDk5rAIbTO4zfbsY-wOvFqdiPpqki5S1Lj5_nOVpleE_BldN6h-GAYv3b291h2F0dG5ldHOIAAAAAAAAAACEZXRoMpBa8xKTIAAAkv__________gmlkgnY0gmlwhApkZAqJc2VjcDI1NmsxoQI778OxC5HP9v87abs54E1H8n8Jo3fVGH2XsQwmBDEI1ohzeW5jbmV0cwCDdGNwgjLIg3VkcIIu4A
-      - --min-sync-peers=1
+      - --min-sync-peers=0
       - --genesis-state=/consensus/genesis.ssz
       - --interop-eth1data-votes
       - --chain-config-file=/consensus/config.yml
@@ -144,50 +72,8 @@ services:
 
   # Runs the go-ethereum execution client with the specified, unlocked account and necessary
   # APIs to allow for proof-of-stake consensus via Prysm.
-  geth:
-    image: "ethereum/client-go:latest"
-    command:
-      - --http
-      - --http.api=eth,net,web3,debug
-      - --http.addr=0.0.0.0
-      - --http.corsdomain=*
-      - --ws
-      - --ws.api=eth,net,web3
-      - --ws.addr=0.0.0.0
-      - --ws.origins=*
-      - --authrpc.vhosts=*
-      - --authrpc.addr=0.0.0.0
-      - --authrpc.jwtsecret=/execution/jwtsecret
-      - --datadir=/execution/geth
-      - --allow-insecure-unlock
-      - --unlock=0x85da99c8a7c2c95964c8efd687e95e632fc533d6
-      - --password=/execution/geth_password.txt
-      - --nodiscover
-      - --syncmode=full
-    ports:
-      - 8551:8551
-      - 8545:8545
-      - 8546:8546
-    depends_on:
-      geth-genesis:
-        condition: service_completed_successfully
-      geth-import:
-        condition: service_completed_successfully
-      beacon-chain-1:
-        condition: service_started
-    volumes:
-      - ./execution:/execution
-      - ./execution/jwtsecret:/execution/jwtsecret
-      - ./execution/geth_password.txt:/execution/geth_password.txt
-    networks:
-      polygon-net:
-        ipv4_address: 10.100.100.12
-
-  # Runs the go-ethereum execution client with the specified, unlocked account and necessary
-  # APIs to allow for proof-of-stake consensus via Prysm.
   erigon:
-    image: "thorax/erigon:devel"
-    user: root
+    image: "thorax/erigon:${ERIGON_IMAGE_TAG:-devel}"
     command:
       - --http
       - --http.api=eth,net,web3,erigon,engine,debug
@@ -200,14 +86,15 @@ services:
       - --datadir=/execution/erigon
       - --nat=extip:10.100.100.13
       - --db.size.limit=1GB
+      - --networkid=32382
     ports:
       - 18551:8551
       - 18545:8545
       - 18546:8546
     depends_on:
-      geth-genesis:
+      erigon-genesis:
         condition: service_completed_successfully
-      beacon-chain-2:
+      beacon-chain:
         condition: service_started
     volumes:
       - ./execution:/execution
@@ -220,16 +107,16 @@ services:
   # We run a validator client with 64, deterministically-generated keys that match
   # The validator keys present in the beacon chain genesis state generated a few steps above.
   validator:
-    image: "gcr.io/prysmaticlabs/prysm/validator:v4.0.8"
+    image: "gcr.io/prysmaticlabs/prysm/validator:v4.2.0"
     command:
-      - --beacon-rpc-provider=beacon-chain-1:4000
+      - --beacon-rpc-provider=beacon-chain:4000
       - --datadir=/consensus/validatordata
       - --accept-terms-of-use
       - --interop-num-validators=64
       - --interop-start-index=0
       - --chain-config-file=/consensus/config.yml
     depends_on:
-      beacon-chain-1:
+      beacon-chain:
         condition: service_started
     volumes:
       - ./consensus:/consensus


### PR DESCRIPTION
This PR introduces the following changes:

- Introduce ARM64 support via `docker-compose-arm.yml` docker-compose file.
- Fix bug relating to mdbx database by adding `--db.size.limit=1GB` flag to the erigon client.
- Fix bug in which erigon was trying to sync to ethereum mainnet instead of the local devnet by adding a `--networkid=32382` to the erigon client.
- Update `README` to add `--db.size.limit=1GB` and `--networkid=32382` flags when running jerigon.
- Removed geth client and setup containers as well as the second beacon node from the arm `docker-compose-arm64.yaml` file.
- Update the validator to use `erigon` as it's execution client.

I have not ported the changes to the original `docker-compose.yaml`